### PR TITLE
Adding missing JsonProperty for GetBalanceRequest

### DIFF
--- a/src/Plaid/Balance/GetBalanceRequest.cs
+++ b/src/Plaid/Balance/GetBalanceRequest.cs
@@ -13,6 +13,7 @@ namespace Acklann.Plaid.Balance
 		/// Gets or sets the options.
 		/// </summary>
 		/// <value>The options.</value>
+		[JsonProperty("options")]
 		public Settings Options { get; set; }
 
 		/// <summary>
@@ -24,6 +25,7 @@ namespace Acklann.Plaid.Balance
 			/// Gets or sets the account ids. Note: An error will be returned if a provided account_id is not associated with the <see cref="Entity.Item"/>.
 			/// </summary>
 			/// <value>The account ids.</value>
+			[JsonProperty("account_ids")]
 			public string[] AccountIds { get; set; }
 		}
 	}


### PR DESCRIPTION
```
POST: https://production.plaid.com/accounts/balance/get : {"Options":{"AccountIds":["abc..."]},"secret":"***","client_id":"123...","access_token":"***"}
---
"RESPONSE (BadRequest): https://production.plaid.com/accounts/balance/get : {
  "display_message": null,
  "documentation_url": "https://plaid.com/docs/?ref=error#invalid-request-errors",
  "error_code": "UNKNOWN_FIELDS",
  "error_message": "the following fields are not recognized by this endpoint: Options",
  "error_type": "INVALID_REQUEST",
  "request_id": "hXuJsZVu7jABTsL",
  "suggested_action": null
}"
```