### PR TITLE
Add support for setting android_package_name on link tokens

### DIFF
--- a/src/Plaid/Management/CreateLinkTokenRequest.cs
+++ b/src/Plaid/Management/CreateLinkTokenRequest.cs
@@ -99,6 +99,13 @@ namespace Acklann.Plaid.Management
         public string RedirectUri { get; set; }
 
         /// <summary>
+        /// Gets or sets the android package name.
+        /// </summary>
+        /// <value>The android package name.</value>
+        [JsonProperty("android_package_name")]
+        public string AndroidPackageName { get; set; }
+
+        /// <summary>
         /// Gets or sets the payment initiation.
         /// </summary>
         /// <value>The payment initiation.</value>


### PR DESCRIPTION
Adds ability to set `android_package_name` when creating link tokens.

In support of https://github.com/LN-Zap/zap-middleware/pull/2311