### PR TITLE
Added min_last_updated_datetime to FetchAccountBalanceAsync

### DIFF
--- a/src/Plaid/Balance/GetBalanceRequest.cs
+++ b/src/Plaid/Balance/GetBalanceRequest.cs
@@ -1,4 +1,5 @@
-﻿using Newtonsoft.Json;
+﻿using System;
+using Newtonsoft.Json;
 
 namespace Acklann.Plaid.Balance
 {
@@ -27,6 +28,12 @@ namespace Acklann.Plaid.Balance
 			/// <value>The account ids.</value>
 			[JsonProperty("account_ids")]
 			public string[] AccountIds { get; set; }
+
+			/// <summary>
+			/// Timestamp indicating the oldest acceptable balance.
+			/// </summary>
+			[JsonProperty("min_last_updated_datetime")]
+			public DateTimeOffset? MinLastUpdatedDatetime { get; set; }
 		}
 	}
 }

--- a/src/Plaid/Balance/GetBalanceRequest.cs
+++ b/src/Plaid/Balance/GetBalanceRequest.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
 
 namespace Acklann.Plaid.Balance
 {
@@ -33,6 +34,7 @@ namespace Acklann.Plaid.Balance
 			/// Timestamp indicating the oldest acceptable balance.
 			/// </summary>
 			[JsonProperty("min_last_updated_datetime")]
+			[JsonConverter(typeof(IsoDateTimeConverter))]
 			public DateTimeOffset? MinLastUpdatedDatetime { get; set; }
 		}
 	}

--- a/src/Plaid/SerializableContent.cs
+++ b/src/Plaid/SerializableContent.cs
@@ -20,7 +20,7 @@ namespace Acklann.Plaid
 		{
 			return JsonConvert.SerializeObject(this, new JsonSerializerSettings()
 			{
-				DateFormatString = "yyyy-MM-ddTHH:mm:ssZ",
+				DateFormatString = "yyyy-MM-dd",
 				NullValueHandling = this.NullValueHandling,
 #if DEBUG
 				Formatting = Formatting.Indented

--- a/src/Plaid/SerializableContent.cs
+++ b/src/Plaid/SerializableContent.cs
@@ -20,7 +20,7 @@ namespace Acklann.Plaid
 		{
 			return JsonConvert.SerializeObject(this, new JsonSerializerSettings()
 			{
-				DateFormatString = "yyyy-MM-dd",
+				DateFormatString = "yyyy-MM-ddTHH:mm:ssZ",
 				NullValueHandling = this.NullValueHandling,
 #if DEBUG
 				Formatting = Formatting.Indented


### PR DESCRIPTION
This is necessary for us to be able to solve https://github.com/ln-zap/zap-middleware/issues/2732. It's been tested via the UI flow, and should be correct, but please test it yourself as well.