### PR TITLE
Add total property to institution response

### DIFF
--- a/src/Plaid/Institution/SearchResponse.cs
+++ b/src/Plaid/Institution/SearchResponse.cs
@@ -14,5 +14,11 @@ namespace Acklann.Plaid.Institution
         /// <value>The institutions.</value>
         [JsonProperty("institutions")]
         public Entity.Institution[] Institutions { get; set; }
+
+        /// <summary>
+        /// Gets or sets the total.
+        /// </summary>
+        [JsonProperty("total")]
+        public int Total { get; set; }
     }
 }


### PR DESCRIPTION
As part of https://github.com/LN-Zap/Plaid.NET/pull/9 and https://github.com/LN-Zap/zap-middleware/issues/9275

Adding `Total` property to institution response; to allow requesting institutions until we reach the total count.