### PR TITLE
Update Newtonsoft from 12.0.3 to 13.0.3

### DIFF
--- a/src/Plaid/Plaid.csproj
+++ b/src/Plaid/Plaid.csproj
@@ -36,7 +36,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Http" Version="3.1.9" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
Update Newtonsoft because of found [vulnerabilities](https://github.com/advisories/GHSA-5crp-9r3c-p9vr)