### PR TITLE
Add Microdeposit error

### DIFF
--- a/src/Plaid/Exceptions/ErrorCode.cs
+++ b/src/Plaid/Exceptions/ErrorCode.cs
@@ -500,6 +500,17 @@ namespace Acklann.Plaid.Exceptions
 
 		#endregion
 
+		#region MICRODEPOSIT Codes
+
+		/// <summary>
+		/// The bank transfer could not be completed because a previous transfer involving the same end-user account resulted in an error.
+		/// </summary>
+		/// <remarks><see href="https://plaid.com/docs/errors/microdeposits/#bank_transfer_account_blocked"/></remarks>
+		[EnumMember(Value = "BANK_TRANSFER_ACCOUNT_BLOCKED")]
+		BankTransferAccountBlocked,
+
+		#endregion
+
 		#region SANDBOX_ERROR Codes
 		/// <summary>
 		/// The requested product is not enabled for an Item


### PR DESCRIPTION
Add missing microdeposit error

https://zapsolutionsinc.slack.com/archives/C065LB2BM6E/p1725485087667459

> ZapMiddleware.External.Plaid.PlaidClientException: Error deserializing Plaid Exception: Unexpected token String when parsing enum.
   at ZapMiddleware.External.Plaid.PlaidFacade.handleException(PlaidException exception) in /src/ZapMiddleware.External/Plaid/PlaidFacade.cs:line 352
   
Seems we could not parse the reason of the error, so instead we returned unsupported error