### PR TITLE
Add project.json that defines basic project tags

### DIFF
--- a/src/Plaid/project.json
+++ b/src/Plaid/project.json
@@ -1,0 +1,6 @@
+{
+  "name": "Plaid",
+  "tags": [
+    "scope:utils"
+  ]
+}


### PR DESCRIPTION
Add a project.json that defines basic project tags, required as part of module boundary enforcement.